### PR TITLE
Add Aptos Hello World example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# aptos-test
+# Aptos Hello World
+
+This repository contains a simple `Move` package that demonstrates a Hello World example on the Aptos blockchain. The package lives in `hello_blockchain/` and defines a module that emits a `Hello, Aptos!` event.
+
+## Prerequisites
+
+- [Aptos CLI](https://github.com/aptos-labs/aptos-core/releases) installed and available in your `PATH`.
+
+## Building
+
+```
+cd hello_blockchain
+aptos move compile
+```
+
+This will compile the Move module using the Aptos CLI.
+
+## Running
+
+To publish the package and emit the Hello World event, use the Aptos CLI with a configured account:
+
+```
+aptos move publish --package-dir hello_blockchain
+aptos move run --function hello_blockchain::hello_blockchain::emit_hello
+```
+
+Make sure your account is funded and the Aptos CLI is properly configured for your chosen network.
+

--- a/hello_blockchain/Move.toml
+++ b/hello_blockchain/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "HelloBlockchain"
+version = "0.0.1"
+
+[addresses]
+hello_blockchain = "0xCAFE"
+
+[dependencies]
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework", rev = "main" }

--- a/hello_blockchain/sources/HelloBlockchain.move
+++ b/hello_blockchain/sources/HelloBlockchain.move
@@ -1,0 +1,24 @@
+module hello_blockchain::hello_blockchain {
+    use aptos_framework::event::{EventHandle, emit_event};
+    use aptos_framework::aptos_account::{self};
+    use std::string;
+
+    struct MessageEvent has drop, store {
+        message: string::String,
+    }
+
+    struct HelloWorld has key {
+        event_handle: EventHandle<MessageEvent>,
+    }
+
+    public entry fun initialize(account: &signer) {
+        let event_handle = aptos_framework::event::new_event_handle<MessageEvent>(account);
+        move_to(account, HelloWorld { event_handle });
+    }
+
+    public entry fun emit_hello(account: &signer) {
+        let hello_world = borrow_global_mut<HelloWorld>(signer::address_of(account));
+        let msg = MessageEvent { message: string::utf8(b"Hello, Aptos!") };
+        emit_event(&mut hello_world.event_handle, msg);
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple Hello World Move package for Aptos
- document how to build and run using Aptos CLI

## Testing
- `aptos move compile -p hello_blockchain` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421e7bc3188322a338c2e64f187458